### PR TITLE
0.3.5

### DIFF
--- a/bin/evertils
+++ b/bin/evertils
@@ -1,39 +1,39 @@
 #!/usr/bin/env ruby
 
-require "date"
-require "time"
-require "json"
-require "optparse"
-require "rbconfig"
-require "evernote-thrift"
-require "net/http"
-require "uri"
-require "fileutils"
-require "cgi"
-require "notifaction"
+require 'date'
+require 'time'
+require 'json'
+require 'optparse'
+require 'rbconfig'
+require 'evernote-thrift'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+require 'cgi'
+require 'notifaction'
 require 'digest/md5'
 require 'mime/types'
 require 'evertils/common'
 require 'yaml'
 
 # include required files
-require_relative "../lib/kernel.rb"
-require_relative "../lib/version.rb"
-require_relative "../lib/helpers/time.rb"
-require_relative "../lib/helpers/results.rb"
-require_relative "../lib/log.rb"
-require_relative "../lib/config.rb"
-require_relative "../lib/request.rb"
-require_relative "../lib/utils.rb"
-require_relative "../lib/logs.rb"
-require_relative "../lib/command.rb"
-require_relative "../lib/model_data.rb"
-require_relative "../lib/controller.rb"
-require_relative "../lib/router.rb"
-require_relative "../lib/model.rb"
-require_relative "../lib/helpers/formatting.rb"
-require_relative "../lib/helpers/evernote-enml.rb"
-require_relative "../lib/helper.rb"
+require_relative '../lib/kernel.rb'
+require_relative '../lib/version.rb'
+require_relative '../lib/helpers/time.rb'
+require_relative '../lib/helpers/results.rb'
+require_relative '../lib/log.rb'
+require_relative '../lib/config.rb'
+require_relative '../lib/request.rb'
+require_relative '../lib/utils.rb'
+require_relative '../lib/logs.rb'
+require_relative '../lib/command.rb'
+require_relative '../lib/model_data.rb'
+require_relative '../lib/controller.rb'
+require_relative '../lib/router.rb'
+require_relative '../lib/model.rb'
+require_relative '../lib/helpers/formatting.rb'
+require_relative '../lib/helpers/evernote-enml.rb'
+require_relative '../lib/helper.rb'
 
 # Modify configuration options here
 $config = Evertils::Cfg.new

--- a/evertils.gemspec
+++ b/evertils.gemspec
@@ -4,17 +4,18 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require './lib/version'
 
 Gem::Specification.new do |s|
-  s.name          = 'evertils'
-  s.version       = Evertils::VERSION
-  s.date          = '2015-07-03'
-  s.summary       = 'EN (heart) CLI'
-  s.description   = 'Evernote utilities for your CLI workflow'
-  s.authors       = ['Ryan Priebe']
-  s.email         = 'hello@ryanpriebe.com'
-  s.files         = `git ls-files`.split($\)
-  s.homepage      = 'http://rubygems.org/gems/evertils'
-  s.license       = 'MIT'
-  s.executables   = 'evertils'
+  s.name                  = 'evertils'
+  s.version               = Evertils::VERSION
+  s.date                  = '2017-10-10'
+  s.summary               = 'EN (heart) CLI'
+  s.description           = 'Evernote utilities for your CLI workflow'
+  s.authors               = ['Ryan Priebe']
+  s.email                 = 'hello@ryanpriebe.com'
+  s.files                 = `git ls-files`.split($\)
+  s.homepage              = 'http://rubygems.org/gems/evertils'
+  s.license               = 'MIT'
+  s.executables           = 'evertils'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_runtime_dependency 'notifaction'
   s.add_runtime_dependency 'mime-types'

--- a/lib/controllers/generate.rb
+++ b/lib/controllers/generate.rb
@@ -17,14 +17,6 @@ module Evertils
         OptionParser.new do |opt|
           opt.banner = "#{Evertils::PACKAGE_NAME} generate timeframe [...-flags]"
 
-          opt.on("-f", "--force", "Force execution") do
-            @force = true
-          end
-
-          opt.on("-s", "--start=START", "Specify a date for the note") do |date|
-            @start = DateTime.parse(date)
-          end
-
           opt.on("-n", "--name=NAME", "A name to pass to the script (not all commands support this flag)") do |name|
             @name = name
           end

--- a/lib/controllers/generate.rb
+++ b/lib/controllers/generate.rb
@@ -50,12 +50,6 @@ module Evertils
         body += to_enml($config.custom_sections[NOTEBOOK_WEEKLY]) unless $config.custom_sections.nil?
         parent_notebook = NOTEBOOK_WEEKLY
 
-        if !@force
-          if !Date.today.monday?
-            Notify.error("Sorry, you can only create new weekly logs on Mondays", {})
-          end
-        end
-
         note = @model.create_note(title: title, body: body, parent_notebook: parent_notebook)
 
         tag_manager = Evertils::Common::Manager::Tag.instance

--- a/lib/controllers/generate.rb
+++ b/lib/controllers/generate.rb
@@ -45,7 +45,6 @@ module Evertils
 
       # generate weekly notes
       def weekly
-        exit(1)
         title = @format.date_templates[NOTEBOOK_WEEKLY]
         body = @format.template_contents(NOTEBOOK_WEEKLY)
         body += to_enml($config.custom_sections[NOTEBOOK_WEEKLY]) unless $config.custom_sections.nil?
@@ -53,9 +52,12 @@ module Evertils
 
         note = @model.create_note(title: title, body: body, parent_notebook: parent_notebook)
 
-        tag_manager = Evertils::Common::Manager::Tag.instance
-        week_tag = tag_manager.find("week-#{DateTime.now.cweek + 1}")
-        note.tag(week_tag.prop(:name))
+        # BUG: inability to tag notes lies somewhere in evertils-common,
+        # specifically in how note.tag works
+        # As this is non-functional, lets not run it - commented out for now
+        # tag_manager = Evertils::Common::Manager::Tag.instance
+        # week_tag = tag_manager.find_or_create("week-#{Date.today.cweek}")
+        # note.tag(week_tag.prop(:name))
       end
 
       # generate monthly notes
@@ -67,9 +69,12 @@ module Evertils
 
         note = @model.create_note(title: title, body: body, parent_notebook: parent_notebook)
 
-        tag_manager = Evertils::Common::Manager::Tag.instance
-        month_tag = tag_manager.find("month-#{DateTime.now.strftime('%-m')}")
-        note.tag(month_tag.prop(:name))
+        # BUG: inability to tag notes lies somewhere in evertils-common,
+        # specifically in how note.tag works
+        # As this is non-functional, lets not run it - commented out for now
+        # tag_manager = Evertils::Common::Manager::Tag.instance
+        # month_tag = tag_manager.find_or_create("month-#{Date.today.month}")
+        # note.tag(month_tag.prop(:name))
       end
 
       # generate monthly task summary templates
@@ -84,11 +89,12 @@ module Evertils
         # create the note from template
         mts_note = @model.create_note(title: title, body: body, parent_notebook: parent_notebook)
 
-        # tag it
-        # TODO: maybe move this out of controller?
-        tag_manager = Evertils::Common::Manager::Tag.instance
-        month_tag = tag_manager.find("month-#{DateTime.now.strftime('%-m')}")
-        mts_note.tag(month_tag.prop(:name))
+        # BUG: inability to tag notes lies somewhere in evertils-common,
+        # specifically in how note.tag works
+        # As this is non-functional, lets not run it - commented out for now
+        # tag_manager = Evertils::Common::Manager::Tag.instance
+        # month_tag = tag_manager.find_or_create("month-#{Date.today.month}")
+        # mts_note.tag(month_tag.prop(:name))
 
         # TODO: commented out until support for multiple tags is added
         # client_tag = tag_manager.find_or_create(@name)
@@ -112,7 +118,7 @@ module Evertils
       def morning
         pq
         daily
-        weekly if Date.today.tuesday?
+        weekly if Date.today.monday?
       end
 
       private

--- a/lib/controllers/generate.rb
+++ b/lib/controllers/generate.rb
@@ -107,9 +107,11 @@ module Evertils
       # creates the notes required to start the day
       #  - priority queue
       #  - daily
+      #  - weekly (if today is Monday)
       def morning
         pq
         daily
+        weekly if Date.today.tuesday?
       end
 
       private

--- a/lib/controllers/generate.rb
+++ b/lib/controllers/generate.rb
@@ -45,6 +45,7 @@ module Evertils
 
       # generate weekly notes
       def weekly
+        exit(1)
         title = @format.date_templates[NOTEBOOK_WEEKLY]
         body = @format.template_contents(NOTEBOOK_WEEKLY)
         body += to_enml($config.custom_sections[NOTEBOOK_WEEKLY]) unless $config.custom_sections.nil?

--- a/lib/helpers/formatting.rb
+++ b/lib/helpers/formatting.rb
@@ -36,16 +36,18 @@ module Evertils
       end
 
       # Template string for note title
-      def date_templates(arg_date = DateTime.now)
-        dow = day_of_week(arg_date.strftime('%a'))
-        end_of_week = arg_date + 4 # days
+      def date_templates
+        current_date = Date.today
+        week_stub = day_of_week(current_date.strftime('%a'))
+        start_of_week = Date.commercial(current_date.year, current_date.cweek, 1)
+        end_of_week = Date.commercial(current_date.year, current_date.cweek, 5)
 
         {
-          :Daily => "Daily Log [#{arg_date.strftime('%B %-d')} - #{dow}]",
-          :Weekly => "Weekly Log [#{arg_date.strftime('%B %-d')} - #{end_of_week.strftime('%B %-d')}]",
-          :Monthly => "Monthly Log [#{arg_date.strftime('%B %Y')}]",
-          :Deployments => "#{arg_date.strftime('%B %-d')} - #{dow}",
-          :'Priority Queue' => "Queue For [#{arg_date.strftime('%B %-d')} - #{dow}]"
+          :Daily => "Daily Log [#{current_date.strftime('%B %-d')} - #{week_stub}]",
+          :Weekly => "Weekly Log [#{start_of_week.strftime('%B %-d')} - #{end_of_week.strftime('%B %-d')}]",
+          :Monthly => "Monthly Log [#{current_date.strftime('%B %Y')}]",
+          :Deployments => "#{current_date.strftime('%B %-d')} - #{week_stub}",
+          :'Priority Queue' => "Queue For [#{current_date.strftime('%B %-d')} - #{week_stub}]"
         }
       end
 

--- a/lib/kernel.rb
+++ b/lib/kernel.rb
@@ -6,14 +6,6 @@ class String
   end
 end
 
-class Fixnum
-  def to_bool
-    return true if self == 1
-    return false if self == 0
-    raise ArgumentError.new("invalid value for Boolean: \"#{self}\"")
-  end
-end
-
 class TrueClass
   def to_i; 1; end
   def to_bool; self; end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Evertils
-  VERSION = "0.3.4".freeze
+  VERSION = '0.3.5'.freeze
 end


### PR DESCRIPTION
* Require ruby 2.4.0
* Minor cleanup
* Fixed a long standing bug that required week notes to be created on Monday, now the start and end of the current week is properly determined regardless which day the note is created on
* Create a weekly note, if today is Monday, as part of morning tasks