### PR TITLE
Implement log-group and log-grep

### DIFF
--- a/lib/evertils/controllers/log.rb
+++ b/lib/evertils/controllers/log.rb
@@ -4,6 +4,7 @@ module Evertils
       def pre_exec
         super
 
+        @note = nil
         @note_helper = Evertils::Helper::Note.instance
         @api_helper = Evertils::Helper::ApiEnmlHandler.new(@config)
       end
@@ -12,11 +13,33 @@ module Evertils
       def message(text = nil)
         return Notify.error('A message is required') if text.nil?
 
-        note = @note_helper.find_note_by_grammar(grammar.to_s)
+        @note = @note_helper.find_note_by_grammar(grammar.to_s)
 
-        return Notify.error('Note not found') if note.entity.nil?
+        return Notify.error('Note not found') if @note.entity.nil?
 
-        modify(note, text)
+        modify_with(text)
+      end
+
+      #
+      # @since 2.2.0
+      def grep(text = nil)
+        return Notify.error('A search term is required') if text.nil?
+
+        @note = @note_helper.find_note_by_grammar(grammar.to_s)
+
+        return Notify.error('Note not found') if @note.entity.nil?
+
+        search_for(text)
+      end
+
+      #
+      # @since 2.2.0
+      def group(text = nil)
+        @note = @note_helper.find_note_by_grammar(grammar.to_s)
+
+        return Notify.error('Note not found') if @note.entity.nil?
+
+        group_by(text)
       end
 
       private
@@ -33,15 +56,13 @@ module Evertils
       end
 
       # Update a note with content
-      def modify(note, text)
-        xml = @api_helper.from_str(note.entity.content)
+      def modify_with(text)
+        xml = @api_helper.from_str(@note.entity.content)
 
         time = Time.now.strftime('%I:%M')
         target = xml.search('en-note').first
 
-        return Notify.error('Unable to log message, triage section not found') if target.nil?
-
-        log_message_txt = "<div>* #{time} - #{text}</div>"
+        log_message_txt = "<div>* #{time} - #{clean(text)}</div>"
 
         # append the log message to the target
         target.add_child(log_message_txt)
@@ -51,9 +72,66 @@ module Evertils
           xml.children[1].remove
         end
 
-        note.entity.content = xml.to_s
+        @note.entity.content = xml.to_s
 
-        Notify.success("Item logged at #{time}") if note.update
+        Notify.success("Item logged at #{time}") if @note.update
+      end
+
+      #
+      # @since 2.2.0
+      def search_for(text)
+        results = grep_results_for(text)
+
+        return Notify.error("No rows matched search query {#{text}}") if results.empty?
+
+        Notify.success("#{results.size} rows matched query {#{text}}")
+        results.each { |res| Notify.info(clean(res)) }
+      end
+
+      #
+      # @since 2.2.0
+      def group_by(text)
+        grouped_results.each_pair do |job_id, rows|
+          Notify.note("#{clean(job_id)} - #{rows.size} occurrences") unless job_id.nil?
+
+          rows.each { |row| Notify.info(clean(row)) }
+        end
+      end
+
+      #
+      # @since 2.2.0
+      def search_nodes
+        xml = @api_helper.from_str(@note.entity.content)
+        target = xml.search('en-note').first
+        nodes = []
+
+        target.children.each do |child|
+          node = child.children.first.to_s
+          nodes.push(clean(node)) unless node.empty? || node == '<br/>'
+        end
+
+        nodes
+      end
+
+      #
+      # @since 2.2.0
+      def grouped_results
+        search_nodes.group_by do |node|
+          match = /- (.*)? -/.match(node)
+          match[1] unless match.nil?
+        end
+      end
+
+      #
+      # @since 2.2.0
+      def grep_results_for(text)
+        search_nodes.select { |line| line.include? text }
+      end
+
+      #
+      # @since 2.2.0
+      def clean(text)
+        text.delete("\n").gsub('&#xA0;', ' ')
       end
     end
   end

--- a/lib/evertils/version.rb
+++ b/lib/evertils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Evertils
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
Search for text in your daily log using log-grep, and filter items using log-group.  Both are non-destructive (do not modify data in the store).

Given a daily log like the following...

```
* 08:10 - 1452 - started coding the form
* 08:15 - 1452 - finished adding the fields
* 08:25 - 1452 - started styling
* 12:00 - 1452 - finished styling
* 12:01 - 00 - lunch
* 01:00 - 2222 - working on oauth implementation
* 02:00 - 2222 - finished oauth
```

```
$ evertils log grep 1452
4 rows matched query {1452}
* 08:10 - 1452 - started coding the form
* 08:15 - 1452 - finished adding the fields
* 08:25 - 1452 - started styling
* 12:00 - 1452 - finished styling
```

```
$ evertils log group
- 1452 - 4 occurrences
* 08:10 - 1452 - started coding the form
* 08:15 - 1452 - finished adding the fields
* 08:25 - 1452 - started styling
* 12:00 - 1452 - finished styling
- 2222 - 2 occurrences
* 01:00 - 2222 - working on oauth implementation
* 02:00 - 2222 - finished oauth
- 00 - 1 occurrences
* 12:01 - 00 - lunch
```

I use this to copy-paste to time tracking and other internal progress tracking tools.  Good for personal audits and goal setting.