### PR TITLE
Log-message prints multiple lines if the message is too long now

### DIFF
--- a/lib/evertils/controllers/log.rb
+++ b/lib/evertils/controllers/log.rb
@@ -1,7 +1,7 @@
 module Evertils
   module Controller
     class Log < Controller::Base
-      WORDS_PER_LINE = 15
+      WORDS_PER_LINE = 20
 
       def pre_exec
         super

--- a/lib/evertils/controllers/log.rb
+++ b/lib/evertils/controllers/log.rb
@@ -1,6 +1,8 @@
 module Evertils
   module Controller
     class Log < Controller::Base
+      WORDS_PER_LINE = 15
+
       def pre_exec
         super
 
@@ -14,10 +16,13 @@ module Evertils
         return Notify.error('A message is required') if text.nil?
 
         @note = @note_helper.find_note_by_grammar(grammar.to_s)
+        text_groups = text.split(' ').each_slice(WORDS_PER_LINE).map do |w|
+          w.join(' ')
+        end
 
         return Notify.error('Note not found') if @note.entity.nil?
 
-        modify_with(text)
+        modify_with(text_groups)
       end
 
       #
@@ -39,7 +44,7 @@ module Evertils
 
         return Notify.error('Note not found') if @note.entity.nil?
 
-        group_by(text)
+        group_by
       end
 
       private
@@ -57,15 +62,7 @@ module Evertils
 
       # Update a note with content
       def modify_with(text)
-        xml = @api_helper.from_str(@note.entity.content)
-
-        time = Time.now.strftime('%I:%M')
-        target = xml.search('en-note').first
-
-        log_message_txt = "<div>* #{time} - #{clean(text)}</div>"
-
-        # append the log message to the target
-        target.add_child(log_message_txt)
+        xml = update_note_content_with(text)
 
         # remove XML processing definition if it is the second element
         if xml.children[1].is_a?(Nokogiri::XML::ProcessingInstruction)
@@ -74,7 +71,20 @@ module Evertils
 
         @note.entity.content = xml.to_s
 
-        Notify.success("Item logged at #{time}") if @note.update
+        Notify.success("Item logged at #{current_time}") if @note.update
+      end
+
+      #
+      # @since 2.2.1
+      def update_note_content_with(text)
+        xml = @api_helper.from_str(@note.entity.content)
+        target = xml.search('en-note').first
+
+        text.each do |line|
+          target.add_child("<div>* #{current_time} - #{clean(line)}</div>")
+        end
+
+        xml
       end
 
       #
@@ -90,7 +100,7 @@ module Evertils
 
       #
       # @since 2.2.0
-      def group_by(text)
+      def group_by
         grouped_results.each_pair do |job_id, rows|
           Notify.note("#{clean(job_id)} - #{rows.size} occurrences") unless job_id.nil?
 
@@ -132,6 +142,10 @@ module Evertils
       # @since 2.2.0
       def clean(text)
         text.delete("\n").gsub('&#xA0;', ' ')
+      end
+
+      def current_time
+        Time.now.strftime('%I:%M')
       end
     end
   end

--- a/lib/evertils/version.rb
+++ b/lib/evertils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Evertils
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
Break your logged messages into 2 lines if they are longer than 20 words (rough determination of max number of chars that display well on a 13in screen in the EN mac client).