### PR TITLE
Portable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See [this document](https://github.com/aapis/evertils/wiki/Logging-Specification
 |generate|Create notes from templates|`evertils generate daily`, `evertils generate morning`, `evertils generate monthly`|
 |log|Interact with a note's content|`evertils log message "I am a message"`, `evertils log grep 2223`, `evertils log group`|
 |change|Change the configured Evernote API token `evertils` is using|`evertils change token`|
+|config|Send your configuration to a secret gist, great for portability|`evertils config push`, `evertils config pull`|
 
 ## Automation
 

--- a/evertils.gemspec
+++ b/evertils.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables           = 'evertils'
   s.required_ruby_version = '>= 2.4.0'
 
+  s.add_runtime_dependency 'evertils-gist', '~> 5.1.2'
   s.add_runtime_dependency 'evertils-common', '~> 0.3.7'
-  s.add_runtime_dependency 'gist', '~> 5.1.0'
   s.add_runtime_dependency 'mime-types', '~> 3.3.1'
   s.add_runtime_dependency 'nokogiri', '~> 1.10.9'
   s.add_runtime_dependency 'notifaction', '~> 0.4.4'

--- a/evertils.gemspec
+++ b/evertils.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |s|
   s.executables           = 'evertils'
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_runtime_dependency 'notifaction', '~> 0.4.4'
-  s.add_runtime_dependency 'mime-types', '~> 3.3.1'
   s.add_runtime_dependency 'evertils-common', '~> 0.3.7'
+  s.add_runtime_dependency 'gist', '~> 5.1.0'
+  s.add_runtime_dependency 'mime-types', '~> 3.3.1'
   s.add_runtime_dependency 'nokogiri', '~> 1.10.9'
+  s.add_runtime_dependency 'notifaction', '~> 0.4.4'
 
-  s.add_development_dependency "bundler", "~> 1.10"
-  s.add_development_dependency "rake", "~> 12.3.3"
+  s.add_development_dependency 'bundler', '~> 1.10'
+  s.add_development_dependency 'rake', '~> 12.3.3'
 end

--- a/lib/evertils.rb
+++ b/lib/evertils.rb
@@ -14,6 +14,7 @@ require 'mime/types'
 require 'evertils/common'
 require 'yaml'
 require 'nokogiri'
+require 'gist'
 # require 'open3'
 
 # include required files

--- a/lib/evertils.rb
+++ b/lib/evertils.rb
@@ -14,7 +14,7 @@ require 'mime/types'
 require 'evertils/common'
 require 'yaml'
 require 'nokogiri'
-require 'gist'
+require 'egist'
 # require 'open3'
 
 # include required files

--- a/lib/evertils/controller.rb
+++ b/lib/evertils/controller.rb
@@ -25,8 +25,6 @@ module Evertils
       def initialize(config, request)
         @config = config
         @request = request
-
-        pre_exec
       end
 
       # Perform pre-run tasks

--- a/lib/evertils/controllers/change.rb
+++ b/lib/evertils/controllers/change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Evertils
   module Controller
     class Change < Controller::Base

--- a/lib/evertils/controllers/config.rb
+++ b/lib/evertils/controllers/config.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'yaml/store'
+
+module Evertils
+  module Controller
+    class Config < Controller::Base
+      def pre_exec
+        conf = contents_of('~/.evertils/config.yml')
+        @token = conf['gist_token'] unless conf['gist_token'].nil?
+        # if the requested gist doesn't exist, ignore it and generate a new one
+        puts @token.inspect
+        @token = nil unless gist_exists?
+        puts gist_exists?
+        puts @token.inspect
+        exit
+
+        Gist.login! unless has_auth_already?
+      end
+
+      def push
+        options = {
+          public: false
+        }
+
+        options.merge!(update: @token) unless @token.nil?
+
+        resp = Gist.multi_gist(payload, options)
+        @token = resp['id'] if resp.key?('id')
+
+        Notify.success("Gist created/updated - #{resp['url']}") if store_token?
+      end
+
+      def pull
+
+      end
+
+      private
+
+      def payload
+        {
+          'config.yml' => contents_of('~/.evertils/config.yml').to_yaml
+        }.merge(types)
+      end
+
+      def contents_of(file)
+        YAML.load_file(File.expand_path(file))
+      end
+
+      def types
+        types = {}
+
+        Dir[File.expand_path('~/.evertils/templates/type/*.yml')].each do |dir|
+          types["templates/type/#{dir.split('/').last}"] = contents_of(dir).to_yaml
+        end
+
+        types
+      end
+
+      def gist_authenticate
+        Gist.login!
+      end
+
+      def gist_exists?
+        # begin
+          Gist.list_all_gists
+          $stdout.flush
+          puts gists.scan(@token).inspect
+
+        # rescue
+        #   false
+        # end
+      end
+
+      def has_auth_already?
+        File.exist?(File.expand_path('~/.gist'))
+      end
+
+      def store_token?
+        store = YAML::Store.new(File.expand_path('~/.evertils/config.yml'))
+        yaml = contents_of('~/.evertils/config.yml')
+
+        store.transaction do
+          yaml.each_pair { |key, value| store[key] = value }
+          store['gist_token'] = @token
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/lib/evertils/controllers/config.rb
+++ b/lib/evertils/controllers/config.rb
@@ -63,13 +63,28 @@ module Evertils
 
       def gist_exists?
         # begin
-          Gist.list_all_gists
-          $stdout.flush
-          puts gists.scan(@token).inspect
+
+
+          gists = with_captured_stdout { puts Gist.list_all_gists }
+          # puts gists.inspect
+
+          # puts gists.scan(@token).inspect
 
         # rescue
         #   false
         # end
+      end
+
+      #
+      # Thanks https://stackoverflow.com/a/22777806/7044855
+      # @since 2.3.0
+      def with_captured_stdout
+        original_stdout = $stdout  # capture previous value of $stdout
+        $stdout = StringIO.new     # assign a string buffer to $stdout
+        yield                      # perform the body of the user code
+        $stdout.string             # return the contents of the string buffer
+      ensure
+        $stdout = original_stdout  # restore $stdout to its previous value
       end
 
       def has_auth_already?

--- a/lib/evertils/controllers/config.rb
+++ b/lib/evertils/controllers/config.rb
@@ -9,8 +9,9 @@ module Evertils
       def pre_exec
         conf = contents_of('~/.evertils/config.yml')
         @token = conf['gist_token'] unless conf['gist_token'].nil?
+        @updating = Gist.gist_exists?(@token)
         # if the requested gist doesn't exist, ignore it and generate a new one
-        @token = nil unless Gist.gist_exists?(@token)
+        @token = nil unless @updating
 
         Gist.login! unless has_auth_already?
       end
@@ -25,7 +26,7 @@ module Evertils
         resp = Gist.multi_gist(payload, options)
         @token = resp['id'] if resp.key?('id')
 
-        Notify.success("Gist created/updated - #{resp['html_url']}") if store_token?
+        Notify.success(message(resp['html_url'])) if store_token?
       end
 
       def pull
@@ -38,7 +39,7 @@ module Evertils
         dir = {}
         t_pfx = '~/.evertils/templates/type'
         c_pfx = '~/.evertils'
-        root_files = ['config.yml', 'rolling.log']
+        root_files = ['config.yml']
 
         files.each_pair do |_, file|
           dir["#{t_pfx}/#{file['filename']}"] = file['content'] unless file['filename'] == 'config.yml'
@@ -52,10 +53,15 @@ module Evertils
 
       private
 
+      def message(url)
+        return "Gist updated - #{url}" if @updating
+
+        "Gist created - #{url}"
+      end
+
       def payload
         {
           'config.yml' => contents_of('~/.evertils/config.yml').to_yaml,
-          'rolling.log' => File.read(File.expand_path('~/.evertils/rolling.log'))
         }.merge(types)
       end
 

--- a/lib/evertils/controllers/config.rb
+++ b/lib/evertils/controllers/config.rb
@@ -30,7 +30,10 @@ module Evertils
       def pull
         files = Gist.download(@token)
 
-        files.each
+        files.each_pair do |_, file|
+          puts file.inspect
+          # rebuild the .evertils folder here
+        end
       end
 
       private

--- a/lib/evertils/controllers/config.rb
+++ b/lib/evertils/controllers/config.rb
@@ -9,11 +9,7 @@ module Evertils
         conf = contents_of('~/.evertils/config.yml')
         @token = conf['gist_token'] unless conf['gist_token'].nil?
         # if the requested gist doesn't exist, ignore it and generate a new one
-        puts @token.inspect
-        @token = nil unless gist_exists?
-        puts gist_exists?
-        puts @token.inspect
-        exit
+        @token = nil unless Gist.gist_exists?(@token)
 
         Gist.login! unless has_auth_already?
       end
@@ -28,11 +24,13 @@ module Evertils
         resp = Gist.multi_gist(payload, options)
         @token = resp['id'] if resp.key?('id')
 
-        Notify.success("Gist created/updated - #{resp['url']}") if store_token?
+        Notify.success("Gist created/updated - #{resp['html_url']}") if store_token?
       end
 
       def pull
+        files = Gist.download(@token)
 
+        files.each
       end
 
       private
@@ -59,32 +57,6 @@ module Evertils
 
       def gist_authenticate
         Gist.login!
-      end
-
-      def gist_exists?
-        # begin
-
-
-          gists = with_captured_stdout { puts Gist.list_all_gists }
-          # puts gists.inspect
-
-          # puts gists.scan(@token).inspect
-
-        # rescue
-        #   false
-        # end
-      end
-
-      #
-      # Thanks https://stackoverflow.com/a/22777806/7044855
-      # @since 2.3.0
-      def with_captured_stdout
-        original_stdout = $stdout  # capture previous value of $stdout
-        $stdout = StringIO.new     # assign a string buffer to $stdout
-        yield                      # perform the body of the user code
-        $stdout.string             # return the contents of the string buffer
-      ensure
-        $stdout = original_stdout  # restore $stdout to its previous value
       end
 
       def has_auth_already?

--- a/lib/evertils/controllers/log.rb
+++ b/lib/evertils/controllers/log.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Evertils
   module Controller
     Formatting = Evertils::Helper::Formatting

--- a/lib/evertils/router.rb
+++ b/lib/evertils/router.rb
@@ -82,18 +82,18 @@ module Evertils
     end
 
     # checks output of gpg --list-keys for the presence of a specific GPG key
-    def verify_gpgKey
+    def verify_gpg_key
       # TODO: replace with Open3
-      res = system("gpg --list-keys  #{@config.get(:required, :gpgKey)} 2>/dev/null >/dev/null")
+      res = system("gpg --list-keys  #{@config.get(:required, :gpg_key)} 2>/dev/null >/dev/null")
 
       raise GpgException unless res
       res
     end
 
     # checks output of ykman list to determine if the correct key is inserted
-    def verify_yubikeySerial
+    def verify_yubikey_serial
       # TODO: replace with Open3
-      res = system("ykman list | grep #{@config.get(:required, :yubikeySerial)} 2>/dev/null >/dev/null")
+      res = system("ykman list | grep #{@config.get(:required, :yubikey_serial)} 2>/dev/null >/dev/null")
 
       raise YubikeyException unless res
       res

--- a/lib/evertils/version.rb
+++ b/lib/evertils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Evertils
-  VERSION = '2.2.4'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
Configuration is now much more portable.  Running `evertils config push` from your setup on one machine sends all your config data to a secret gist on github (you have to authenticate first).  You will have to be running at least 2.3.0 to pull configuration down, then you would use `evertils config pull`.